### PR TITLE
Refactor Determinant Code

### DIFF
--- a/MatrixShell.py
+++ b/MatrixShell.py
@@ -19,7 +19,8 @@ class MatrixShell:
     def __add__(self, other):
         if self.nr_row == other.nr_row and self.nr_col == other.nr_col:
             dummy = MatrixShell(len(self.matrix), len(self.matrix[0]), 1)
-            dummy.matrix = [[0 for i in range(len(self.matrix[0]))] for j in range(len(self.matrix))]
+            dummy.matrix = [[0 for i in range(len(self.matrix[0]))]
+                            for j in range(len(self.matrix))]
             for i in range(len(self.matrix)):
                 for j in range(len(self.matrix[0])):
                     dummy.matrix[i][j] = self.matrix[i][j] + other.matrix[i][j]
@@ -32,7 +33,8 @@ class MatrixShell:
     def __radd__(self, other):
         if self.nr_row == other.nr_row and self.nr_col == other.nr_col:
             dummy = MatrixShell(len(self.matrix), len(self.matrix[0]), 1)
-            dummy.matrix = [[0 for i in range(len(self.matrix[0]))] for j in range(len(self.matrix))]
+            dummy.matrix = [[0 for i in range(len(self.matrix[0]))]
+                            for j in range(len(self.matrix))]
             for i in range(len(self.matrix)):
                 for j in range(len(self.matrix[0])):
                     dummy.matrix[i][j] = self.matrix[i][j] + other.matrix[i][j]
@@ -45,7 +47,8 @@ class MatrixShell:
     def __sub__(self, other):
         if self.nr_row == other.nr_row and self.nr_col == other.nr_col:
             dummy = MatrixShell(len(self.matrix), len(self.matrix[0]), 1)
-            dummy.matrix = [[0 for i in range(len(self.matrix[0]))] for j in range(len(self.matrix))]
+            dummy.matrix = [[0 for i in range(len(self.matrix[0]))]
+                            for j in range(len(self.matrix))]
             for i in range(len(self.matrix)):
                 for j in range(len(self.matrix[0])):
                     dummy.matrix[i][j] = self.matrix[i][j] - other.matrix[i][j]
@@ -58,7 +61,8 @@ class MatrixShell:
     def __rsub__(self, other):
         if self.nr_row == other.nr_row and self.nr_col == other.nr_col:
             dummy = MatrixShell(len(self.matrix), len(self.matrix[0]), 1)
-            dummy.matrix = [[0 for i in range(len(self.matrix[0]))] for j in range(len(self.matrix))]
+            dummy.matrix = [[0 for i in range(len(self.matrix[0]))]
+                            for j in range(len(self.matrix))]
             for i in range(len(self.matrix)):
                 for j in range(len(self.matrix[0])):
                     dummy.matrix[i][j] = other.matrix[i][j] - self.matrix[i][j]
@@ -163,16 +167,16 @@ class MatrixShell:
 
     def det(self):
         import determinant
-        return determinant.determinant(self.matrix)
+        return determinant.matrix_determinant(self.matrix)
 
     def adjugate(self):
-        from determinant import determinant
+        from determinant import matrix_determinant
         from minor import minor, transpose
         matrix = self.matrix
         lst = []
         for i in range(len(matrix)):
             for j in range(len(matrix)):
-                lst.append((-1) ** (i + j) * determinant(minor(matrix, i, j)))
+                lst.append((-1) ** (i + j) * matrix_determinant(minor(matrix, i, j)))
 
         dummy = [[0 for i in range(len(matrix))] for j in range(len(matrix))]
         for k in range(len(matrix)):
@@ -207,8 +211,8 @@ class MatrixShell:
             for i in range(len(vector)):
                 removed = matrix_transposed.pop(i)
                 matrix_transposed.insert(i, vector)
-                from determinant import determinant
-                ans.append(determinant(matrix_transposed) / d)
+                from determinant import matrix_determinant
+                ans.append(matrix_determinant(matrix_transposed) / d)
                 matrix_transposed.pop(i)
                 matrix_transposed.insert(i, removed)
 

--- a/determinant.py
+++ b/determinant.py
@@ -1,179 +1,83 @@
-from minor import minor
+from typing import Union
+matrix = list[list[Union[int, float]]]
 
 
-def det1x1(matrix):
-    return matrix[0][0]
+cache = {}
+def matrix_determinant(mat_a: matrix, round_int: int = 2) -> float:
+    """Calculates the determinant of a matrix. Uses a recursive function until it finds a 2x2 matrix
+    
+    
+    Args:
+    --------
+        `mat_a (matrix)`: any matrix
+        `round_int`: how many decimal places to round to. Default: 2
+    
+    
+    Returns:
+    --------
+        `float`: matrix determinant
+    
+    Examples:
+    --------
+    >>> matrix_determinant([[1, 2], [3, 4]])
+    >>> output: -2
+    --------
+    >>> matrix_determinant([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
+    >>> output: 0
+    --------
+    >>> matrix_determinant([[1, 3, 1, 4], [3, 9, 5, 15], [0, 2, 1, 1], [0, 4, 2, 3]])
+    >>> output: -4
+    """
+    #? checking if its a valid and square matrix
+    if not isinstance(mat_a, list):
+        raise TypeError("Not a valid matrix.")
+    if len(mat_a) != len(mat_a[0]):
+        raise ValueError("Not a square matrix.")
+    
+    #? if the matrix is a 1x1, return the value
+    if len(mat_a) == 1 and len(mat_a[0]) == 1:
+        return mat_a[0][0]
+    
+    if len(mat_a) == 2:
+        return mat_a[0][0] * mat_a[1][1] - mat_a[0][1] * mat_a[1][0]
+    
+    if str(mat_a) in cache:
+        return cache[str(mat_a)]
+    else:
+        cache[str(mat_a)] = None
+    
+    soma: float = 0
+    for i in range(len(mat_a)):
+        soma += (-1)**i * mat_a[0][i] * matrix_determinant(matrix_submatrix(mat_a, i))
+    cache[str(mat_a)] = round(soma, round_int)
+    return cache[str(mat_a)]
 
 
-def det2x2(matrix):
-    return matrix[0][0] * matrix[1][1] - matrix[0][1] * matrix[1][0]
-
-
-def det3x3(matrix):
-    a = matrix[0][0]
-    b = matrix[0][1]
-    c = matrix[0][2]
-    d = matrix[1][0]
-    e = matrix[1][1]
-    f = matrix[1][2]
-    g = matrix[2][0]
-    h = matrix[2][1]
-    i = matrix[2][2]
-    return a * e * i + b * f * g + c * d * h - c * e * g - a * f * h - b * d * i
-
-
-def det4x4(matrix):
-    ans = 0
-    depth = 4
-    row = matrix[0]
-    for i in range(len(matrix[0])):
-        ans += (-1) ** i * row[i] * det[depth - 1](minor(matrix, 0, i))
-    return ans
-
-
-def det5x5(matrix):
-    ans = 0
-    depth = 5
-    row = matrix[0]
-    for i in range(len(matrix[0])):
-        ans += (-1) ** i * row[i] * det[depth - 1](minor(matrix, 0, i))
-    return ans
-
-
-def det6x6(matrix):
-    ans = 0
-    depth = 6
-    row = matrix[0]
-    for i in range(len(matrix[0])):
-        ans += (-1) ** i * row[i] * det[depth - 1](minor(matrix, 0, i))
-    return ans
-
-
-def det7x7(matrix):
-    ans = 0
-    depth = 7
-    row = matrix[0]
-    for i in range(len(matrix[0])):
-        ans += (-1) ** i * row[i] * det[depth - 1](minor(matrix, 0, i))
-    return ans
-
-
-def det8x8(matrix):
-    ans = 0
-    depth = 8
-    row = matrix[0]
-    for i in range(len(matrix[0])):
-        ans += (-1) ** i * row[i] * det[depth - 1](minor(matrix, 0, i))
-    return ans
-
-
-def det9x9(matrix):
-    ans = 0
-    depth = 9
-    row = matrix[0]
-    for i in range(len(matrix[0])):
-        ans += (-1) ** i * row[i] * det[depth - 1](minor(matrix, 0, i))
-    return ans
-
-
-def det10x10(matrix):
-    ans = 0
-    depth = 10
-    row = matrix[0]
-    for i in range(len(matrix[0])):
-        ans += (-1) ** i * row[i] * det[depth - 1](minor(matrix, 0, i))
-    return ans
-
-
-def det11x11(matrix):
-    ans = 0
-    depth = 11
-    row = matrix[0]
-    for i in range(len(matrix[0])):
-        ans += (-1) ** i * row[i] * det[depth - 1](minor(matrix, 0, i))
-    return ans
-
-
-def det12x12(matrix):
-    ans = 0
-    depth = 12
-    row = matrix[0]
-    for i in range(len(matrix[0])):
-        ans += (-1) ** i * row[i] * det[depth - 1](minor(matrix, 0, i))
-    return ans
-
-
-def det13x13(matrix):
-    ans = 0
-    depth = 13
-    row = matrix[0]
-    for i in range(len(matrix[0])):
-        ans += (-1) ** i * row[i] * det[depth - 1](minor(matrix, 0, i))
-    return ans
-
-
-def det14x14(matrix):
-    ans = 0
-    depth = 14
-    row = matrix[0]
-    for i in range(len(matrix[0])):
-        ans += (-1) ** i * row[i] * det[depth - 1](minor(matrix, 0, i))
-    return ans
-
-
-def det15x15(matrix):
-    ans = 0
-    depth = 15
-    row = matrix[0]
-    for i in range(len(matrix[0])):
-        ans += (-1) ** i * row[i] * det[depth - 1](minor(matrix, 0, i))
-    return ans
-
-
-def det16x16(matrix):
-    ans = 0
-    depth = 16
-    row = matrix[0]
-    for i in range(len(matrix[0])):
-        ans += (-1) ** i * row[i] * det[depth - 1](minor(matrix, 0, i))
-    return ans
-
-
-def det17x17(matrix):
-    ans = 0
-    depth = 17
-    row = matrix[0]
-    for i in range(len(matrix[0])):
-        ans += (-1) ** i * row[i] * det[depth - 1](minor(matrix, 0, i))
-    return ans
-
-
-def det18x18(matrix):
-    ans = 0
-    depth = 18
-    row = matrix[0]
-    for i in range(len(matrix[0])):
-        ans += (-1) ** i * row[i] * det[depth - 1](minor(matrix, 0, i))
-    return ans
-
-
-def det19x19(matrix):
-    ans = 0
-    depth = 19
-    row = matrix[0]
-    for i in range(len(matrix[0])):
-        ans += (-1) ** i * row[i] * det[depth - 1](minor(matrix, 0, i))
-    return ans
-
-
-det = [0, det1x1, det2x2, det3x3, det4x4, det5x5,
-       det6x6, det7x7, det8x8, det9x9, det10x10,
-       det11x11, det12x12, det13x13, det14x14,
-       det15x15, det16x16, det17x17, det18x18, det19x19]
-
-
-def determinant(matrix):
-    return det[len(matrix)](matrix)
-
-
-
+def matrix_submatrix(mat_a: matrix, column: int) -> matrix:
+    """Used internally by matrix_determinant(). Given a matrix of size `n` x `n`, returns a matrix of size `n-1` x `n-1` where
+    we remove the row and column of the value of `matriz[0][column]`
+    
+    Args:
+    --------
+    mat_a (matriz): any matrix of size `n` x `n`
+    column (int): the column of the value to be removed
+    
+    Returns:
+    --------
+        matriz: a matrix of size `n-1` x `n-1`
+    
+    Examples:
+    --------
+    >>> matrix_submatrix([[1, 2, 3], [4, 5, 6], [7, 8, 9]], 0)
+    >>> output: [[5, 6], [8, 9]]
+    --------
+    >>> matrix_submatrix([[1, 2, 3], [4, 5, 6], [7, 8, 9]], 1)
+    >>> output: [[1, 3], [7, 9]]
+    """
+    matriz_retorno: matrix = []
+    for linha in mat_a[1:]:
+        matriz_retorno.append([])
+        for val, col in enumerate(linha):
+            if val != column:
+                matriz_retorno[-1].append(col)
+    return matriz_retorno


### PR DESCRIPTION
Managed to refactor the code to use less hard coded functions and instead use 2 functions only. It calculates the determinant of a matrix `n` x `n` by performing a series of row and column reductions until it finds a 2 x 2 matrix. I got the idea from [MathIsFun](https://www.mathsisfun.com/algebra/matrix-determinant.html). 

With this changes, you are now able to calculate the determinant for any size matrix although not recommended, since for matrices with sizes > 200 will get very slow (It is better now that I added memorization and a cache, for 100 x 100 was taking 6s not it takes 0.1s)

Here is a print of the code in action to check if it didn't break the original code:

![TestDetereminant](https://user-images.githubusercontent.com/89294396/142776393-2c41ec81-9f2c-42b4-8030-1a1d40b879a5.png)

And here is the expected result using WolframAlpha:

![ConfirmingDeterminantResult](https://user-images.githubusercontent.com/89294396/142776409-a75dd683-d961-4b42-abda-b88fe964559c.png)